### PR TITLE
#491 Certificate frequency & Synchronous processing

### DIFF
--- a/config/functions/cron.js
+++ b/config/functions/cron.js
@@ -19,10 +19,10 @@ module.exports = {
 const generateProgramEnrollmentCertificates = async () => {
   const programEnrollments = await strapi.services['program-enrollments'].find({ medha_program_certificate_status: 'processing', _limit: 3 });
   console.log('programEnrollments', programEnrollments.length);
-  programEnrollments.forEach(async programEnrollment => {
+  for (const programEnrollment of programEnrollments) {
     // create the certificate
     await strapi.services['program-enrollments'].generateCertificate(programEnrollment);
-  });
+  }
 }
 
 const processRegistrationDateLatestForStudents = async () => {


### PR DESCRIPTION
Targets https://github.com/gitmedha/medha-react-ui/issues/491

### Summary
1. Reduced certificate to process per minute from 4 to 3
2. Updated loop structure to not proceed to next certificate if the current ongoing certificate generation is finished